### PR TITLE
Implement incremental/diff-based packing with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ vendor/bin/repophp pack output.txt https://github.com/vangelis183/repophp.git --
 vendor/bin/repophp pack output.txt /path/to/repo --max-tokens=100000 --encoding cl100k_base
 ```
 
+**Incremental packing (diff mode):**
+
+```bash
+vendor/bin/repophp pack output.txt /path/to/repo --incremental --base-file=/path/to/previous/pack.txt
+```
+This will create a diff file containing only files that have changed since the previous pack, which is especially useful for large repositories where you only want to analyze recent changes.
+
 #### Breakdown:
 - Packs the repository located at `/path/to/repository` or clones the remote repository URL.
 - Stores the packed content in `/path/to/output.txt`.
@@ -145,7 +152,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 - [x] Add option for remote Git Repositories
 - [x] Add option for specific branch
 - [x] Add repository splitting for large codebases
-- [ ] Implement incremental/diff-based packing
+- [x] Implement incremental/diff-based packing
 - [ ] Add editable custom config to override defaults
 - [ ] Add security checks for files (Keys, Passwords etc.)
 - [ ] Create advanced filtering options (by date, content)

--- a/src/Command/PackCommand.php
+++ b/src/Command/PackCommand.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Vangelis\RepoPHP\Exceptions\GitRepositoryException;
 use Vangelis\RepoPHP\RepoPHP;
 use Vangelis\RepoPHP\Services\GitRepositoryService;
@@ -129,13 +129,15 @@ class PackCommand extends Command
             }
 
             // Validate incremental mode requirements
-            if ($incrementalMode && !$baseFilePath) {
+            if ($incrementalMode && ! $baseFilePath) {
                 $output->writeln('<error>Base file is required for incremental packing. Use --base-file option.</error>');
+
                 return Command::FAILURE;
             }
 
-            if ($incrementalMode && !file_exists($baseFilePath)) {
+            if ($incrementalMode && ! file_exists($baseFilePath)) {
                 $output->writeln('<error>Base file does not exist: ' . $baseFilePath . '</error>');
+
                 return Command::FAILURE;
             }
 
@@ -156,6 +158,7 @@ class PackCommand extends Command
 
                     if ($answer === 'cancel') {
                         $output->writeln('<info>Operation cancelled.</info>');
+
                         return Command::SUCCESS;
                     } elseif ($answer === 'diff') {
                         // Already handled by the RepoPHP class
@@ -167,7 +170,7 @@ class PackCommand extends Command
                         false
                     );
 
-                    if (!$helper->ask($input, $output, $question)) {
+                    if (! $helper->ask($input, $output, $question)) {
                         // User chose not to overwrite, create a new filename with timestamp
                         $pathInfo = pathinfo($outputPath);
                         $newFilename = sprintf(

--- a/src/RepoPHP.php
+++ b/src/RepoPHP.php
@@ -13,8 +13,8 @@ use Vangelis\RepoPHP\Factory\FormatterFactory;
 use Vangelis\RepoPHP\Services\FileCollector;
 use Vangelis\RepoPHP\Services\FileWriter;
 use Vangelis\RepoPHP\Services\FormatValidator;
-use Vangelis\RepoPHP\Services\PathValidator;
 use Vangelis\RepoPHP\Services\GitDiffService;
+use Vangelis\RepoPHP\Services\PathValidator;
 
 class RepoPHP
 {
@@ -79,7 +79,7 @@ class RepoPHP
 
     public function pack(): void
     {
-        if ($this->incrementalMode && !$this->baseFilePath) {
+        if ($this->incrementalMode && ! $this->baseFilePath) {
             throw new \InvalidArgumentException('Base file is required for incremental packing');
         }
 
@@ -183,12 +183,12 @@ class RepoPHP
 
     private function getChangedFiles(): array
     {
-        if (!$this->gitDiffService) {
+        if (! $this->gitDiffService) {
             return [];
         }
 
         $baseCommit = $this->gitDiffService->getLastPackCommit($this->baseFilePath);
-        if (!$baseCommit) {
+        if (! $baseCommit) {
             throw new \RuntimeException('Could not determine base commit from the base file');
         }
 

--- a/src/Services/FileWriter.php
+++ b/src/Services/FileWriter.php
@@ -24,6 +24,8 @@ class FileWriter
 
     private array $binaryFiles = [];
 
+    private array $incrementalInfo = [];
+
     private readonly ?OutputInterface $output;
 
     private readonly string $outputPath;
@@ -196,6 +198,15 @@ class FileWriter
                 }
             }
 
+            // Add incremental info if available
+            if (!empty($this->incrementalInfo)) {
+                $this->output->writeln("\n📝 Incremental Pack Information:");
+                $this->output->writeln("─────────────────────────────────");
+                $this->output->writeln(sprintf("   Base File: %s", $this->incrementalInfo['baseFile']));
+                $this->output->writeln(sprintf("   Base Commit: %s", $this->incrementalInfo['baseCommit'] ?? 'Unknown'));
+                $this->output->writeln(sprintf("   Changed Files: %d", $this->incrementalInfo['changedFiles']));
+            }
+
             $this->output->writeln('');
         }
     }
@@ -218,5 +229,10 @@ class FileWriter
         $this->fileStats = [];
         $this->binaryFiles = [];
         $this->unreadableFiles = [];
+    }
+
+    public function setIncrementalInfo(array $info): void
+    {
+        $this->incrementalInfo = $info;
     }
 }

--- a/src/Services/FileWriter.php
+++ b/src/Services/FileWriter.php
@@ -199,7 +199,7 @@ class FileWriter
             }
 
             // Add incremental info if available
-            if (!empty($this->incrementalInfo)) {
+            if (! empty($this->incrementalInfo)) {
                 $this->output->writeln("\n📝 Incremental Pack Information:");
                 $this->output->writeln("─────────────────────────────────");
                 $this->output->writeln(sprintf("   Base File: %s", $this->incrementalInfo['baseFile']));

--- a/src/Services/GitDiffService.php
+++ b/src/Services/GitDiffService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vangelis\RepoPHP\Services;
+
+use Vangelis\RepoPHP\Exceptions\GitRepositoryException;
+
+class GitDiffService
+{
+    private ?string $repositoryPath;
+
+    public function __construct(?string $repositoryPath = null)
+    {
+        $this->repositoryPath = $repositoryPath;
+    }
+
+    /**
+     * Get files changed since the specified commit
+     *
+     * @param string $baseCommit Base commit hash to compare against
+     * @return array<string> List of changed file paths
+     * @throws GitRepositoryException
+     */
+    public function getChangedFilesSinceCommit(string $baseCommit): array
+    {
+        $this->validateGitRepository();
+
+        $command = sprintf(
+            'cd %s && git diff --name-only %s HEAD',
+            escapeshellarg($this->repositoryPath),
+            escapeshellarg($baseCommit)
+        );
+
+        exec($command, $output, $returnCode);
+
+        if ($returnCode !== 0) {
+            throw new GitRepositoryException("Failed to get diff with base commit: $baseCommit");
+        }
+
+        return array_filter($output); // Filter out any empty lines
+    }
+
+    /**
+     * Get the commit hash from the last pack
+     *
+     * @param string $baseFilePath Path to the base file
+     * @return string|null Commit hash if found, null otherwise
+     */
+    public function getLastPackCommit(string $baseFilePath): ?string
+    {
+        if (!file_exists($baseFilePath)) {
+            return null;
+        }
+
+        $content = file_get_contents($baseFilePath);
+        if ($content === false) {
+            return null;
+        }
+
+        // Extract commit hash from the file header
+        if (preg_match('/Commit: ([a-f0-9]{7,40})/i', $content, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate that the repository path is a git repository
+     *
+     * @throws GitRepositoryException
+     */
+    private function validateGitRepository(): void
+    {
+        if (!$this->repositoryPath || !is_dir($this->repositoryPath)) {
+            throw new GitRepositoryException('Repository path is not valid');
+        }
+
+        if (!is_dir($this->repositoryPath . '/.git')) {
+            throw new GitRepositoryException('Not a git repository');
+        }
+    }
+}

--- a/src/Services/GitDiffService.php
+++ b/src/Services/GitDiffService.php
@@ -49,7 +49,7 @@ class GitDiffService
      */
     public function getLastPackCommit(string $baseFilePath): ?string
     {
-        if (!file_exists($baseFilePath)) {
+        if (! file_exists($baseFilePath)) {
             return null;
         }
 
@@ -73,11 +73,11 @@ class GitDiffService
      */
     private function validateGitRepository(): void
     {
-        if (!$this->repositoryPath || !is_dir($this->repositoryPath)) {
+        if (! $this->repositoryPath || ! is_dir($this->repositoryPath)) {
             throw new GitRepositoryException('Repository path is not valid');
         }
 
-        if (!is_dir($this->repositoryPath . '/.git')) {
+        if (! is_dir($this->repositoryPath . '/.git')) {
             throw new GitRepositoryException('Not a git repository');
         }
     }

--- a/tests/Unit/RepoPHPIncrementalTest.php
+++ b/tests/Unit/RepoPHPIncrementalTest.php
@@ -71,7 +71,7 @@ class RepoPHPIncrementalTest extends TestCase
 
     private function removeDirectory(string $dir): void
     {
-        if (!is_dir($dir)) {
+        if (! is_dir($dir)) {
             return;
         }
 

--- a/tests/Unit/RepoPHPIncrementalTest.php
+++ b/tests/Unit/RepoPHPIncrementalTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vangelis\RepoPHP\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Vangelis\RepoPHP\Config\RepoPHPConfig;
+use Vangelis\RepoPHP\RepoPHP;
+
+class RepoPHPIncrementalTest extends TestCase
+{
+    private string $testRepoPath;
+    private string $outputPath;
+    private string $diffOutputPath;
+    private ?string $tokenCounterPath = null;
+
+    protected function setUp(): void
+    {
+        // Create a temporary test repository
+        $this->testRepoPath = sys_get_temp_dir() . '/repophp_inc_test_' . uniqid();
+        mkdir($this->testRepoPath, 0777, true);
+
+        // Create output directory
+        $outputDir = sys_get_temp_dir() . '/repophp_inc_output_' . uniqid();
+        mkdir($outputDir, 0755, true);
+        $this->outputPath = $outputDir . '/output.txt';
+        $this->diffOutputPath = $outputDir . '/output_diff_' . date('Y-m-d_His') . '.txt';
+
+        // Setup token counter in a temporary location
+        $this->setupTokenCounter();
+
+        // Initialize git repository
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' init');
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' config user.name "Test User"');
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' config user.email "test@example.com"');
+
+        // Create initial files
+        file_put_contents($this->testRepoPath . '/file1.php', '<?php echo "Initial file 1"; ?>');
+        file_put_contents($this->testRepoPath . '/file2.php', '<?php echo "Initial file 2"; ?>');
+
+        // Add and commit initial files
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' add .');
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' commit -m "Initial commit"');
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up test files and directories
+        $this->removeDirectory($this->testRepoPath);
+        $this->removeDirectory(dirname($this->outputPath));
+
+        if ($this->tokenCounterPath !== null) {
+            $this->removeDirectory(dirname($this->tokenCounterPath));
+        }
+    }
+
+    private function setupTokenCounter(): void
+    {
+        // Same implementation as in RepoPHPSplittingTest
+        $tempDir = sys_get_temp_dir() . '/repophp_inc_token_counter_' . uniqid();
+        mkdir($tempDir, 0777, true);
+
+        $tempTokenCounter = $tempDir . '/mock-token-counter';
+        file_put_contents($tempTokenCounter, '#!/bin/bash' . PHP_EOL . 'echo "10"');
+        chmod($tempTokenCounter, 0777);
+
+        $this->tokenCounterPath = $tempTokenCounter;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = scandir($dir);
+        foreach ($files as $file) {
+            if ($file !== '.' && $file !== '..') {
+                $path = $dir . '/' . $file;
+                if (is_dir($path)) {
+                    $this->removeDirectory($path);
+                } else {
+                    unlink($path);
+                }
+            }
+        }
+        rmdir($dir);
+    }
+
+    public function testIncrementalPacking(): void
+    {
+        // Skip if we couldn't set up a token counter
+        if ($this->tokenCounterPath === null) {
+            $this->markTestSkipped('No token counter available for testing');
+        }
+
+        // Create initial pack
+        $output = new BufferedOutput();
+        $repoPHP = new RepoPHP(
+            $this->testRepoPath,
+            $this->outputPath,
+            RepoPHPConfig::FORMAT_PLAIN,
+            [],
+            false,
+            $output,
+            RepoPHPConfig::ENCODING_CL100K,
+            false,
+            $this->tokenCounterPath
+        );
+        $repoPHP->pack();
+
+        // Verify initial pack contains both files
+        $this->assertFileExists($this->outputPath);
+        $initialContent = file_get_contents($this->outputPath);
+        $this->assertStringContainsString('file1.php', $initialContent);
+        $this->assertStringContainsString('file2.php', $initialContent);
+
+        // Make changes to the repository
+        file_put_contents($this->testRepoPath . '/file1.php', '<?php echo "Modified file 1"; ?>');
+        file_put_contents($this->testRepoPath . '/file3.php', '<?php echo "New file 3"; ?>');
+
+        // Add and commit changes
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' add .');
+        exec('git -C ' . escapeshellarg($this->testRepoPath) . ' commit -m "Update files"');
+
+        // Create incremental pack
+        $diffOutput = new BufferedOutput();
+        $outputDir = dirname($this->outputPath);
+
+        // Use the actual output path rather than a pre-determined one
+        $incrementalOutputPath = $outputDir . '/incremental_output.txt';
+
+        $repoPHPIncremental = new RepoPHP(
+            $this->testRepoPath,
+            $incrementalOutputPath,
+            RepoPHPConfig::FORMAT_PLAIN,
+            [],
+            false,
+            $diffOutput,
+            RepoPHPConfig::ENCODING_CL100K,
+            false,
+            $this->tokenCounterPath,
+            0, // No token limit
+            true, // Enable incremental mode
+            $this->outputPath // Use initial pack as base file
+        );
+        $repoPHPIncremental->pack();
+
+        // Find the actual diff file that was created
+        $diffFiles = glob($outputDir . '/*_diff_*');
+        $this->assertNotEmpty($diffFiles, 'No diff file was created');
+        $diffFilePath = reset($diffFiles);
+
+        // Verify the incremental pack contains only the changed and new files
+        $diffContent = file_get_contents($diffFilePath);
+        $this->assertStringContainsString('file1.php', $diffContent);
+        $this->assertStringContainsString('file3.php', $diffContent);
+        $this->assertStringNotContainsString('file2.php', $diffContent);
+
+        // Verify the console output mentions it's an incremental pack
+        $outputText = $diffOutput->fetch();
+        $this->assertStringContainsString('Incremental Pack Information', $outputText);
+        $this->assertStringContainsString('Base File:', $outputText);
+    }
+}


### PR DESCRIPTION

This commit adds incremental/diff-based packing functionality to RepoPHP. The feature allows users to create differential pack files that contain only files that have changed since a previous pack, which is especially useful for large repositories where you only want to analyze recent changes.

Key changes include:

- Added --incremental and --base-file options to the pack command
- Implemented GitDiffService to detect changes between repository versions
- Added naming convention for diff files with timestamps
- Enhanced FileWriter to include incremental pack metadata
- Implemented robust unit tests for the incremental functionality

When using incremental mode, RepoPHP now identifies changed files based on Git history, comparing against a previous pack file, and only includes modified or new files in the output.