### PR TITLE
Implement editable custom config to override defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,42 @@ You can install the package via composer:
 ```bash  
 composer require vangelis/repophp --dev
 ```  
+
+## Configuration File
+
+RepoPHP supports a configuration file to set default options. Create one of these files in your project directory:
+- `.repophp.json`
+- `repophp.json`
+- `.repophp.config.json`
+- `repophp.config.json`
+
+Example configuration file:
+
+```json
+{
+  "repository": "/path/to/repository",
+  "output": "packed_repo.txt",
+  "format": "markdown",
+  "encoding": "cl100k_base",
+  "exclude": [".env.local", "*.log"],
+  "no-gitignore": false,
+  "compress": true,
+  "max-tokens": 100000,
+  "remote": false,
+  "branch": "main",
+  "incremental": false,
+  "base-file": null
+}
+```
+
+With this configuration file in place, you can simply run:
+
+```bash
+vendor/bin/repophp pack
+```
+
+Command-line arguments will override settings from the configuration file.
+
   
 ## Usage  
 ## Pack Command Usage  

--- a/src/Command/PackCommand.php
+++ b/src/Command/PackCommand.php
@@ -104,26 +104,29 @@ class PackCommand extends Command
         // Load configuration from file if exists
         try {
             $fileConfig = ConfigLoader::loadConfig();
-            if (!empty($fileConfig)) {
+            if (! empty($fileConfig)) {
                 $output->writeln('<info>Using configuration from file</info>');
             }
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+
             return Command::FAILURE;
         }
 
         // Get repository argument or from config file
         $repository = $input->getArgument('repository') ?? $fileConfig['repository'] ?? null;
-        if (!$repository) {
+        if (! $repository) {
             $output->writeln('<error>Repository path is required</error>');
+
             return Command::FAILURE;
         }
 
         // Apply config file defaults but let CLI options override them
         $isRemote = $input->getOption('remote') ?? $fileConfig['remote'] ?? false;
         $outputPath = $input->getArgument('output') ?? $fileConfig['output'] ?? null;
-        if (!$outputPath) {
+        if (! $outputPath) {
             $output->writeln('<error>Output path is required</error>');
+
             return Command::FAILURE;
         }
 
@@ -131,7 +134,7 @@ class PackCommand extends Command
         $format = $input->getOption('format') ?? $fileConfig['format'] ?? 'plain';
         $encoding = $input->getOption('encoding') ?? $fileConfig['encoding'] ?? 'p50k_base';
         $excludePatterns = $input->getOption('exclude') ?: ($fileConfig['exclude'] ?? []);
-        $respectGitignore = !($input->getOption('no-gitignore') ?? $fileConfig['no-gitignore'] ?? false);
+        $respectGitignore = ! ($input->getOption('no-gitignore') ?? $fileConfig['no-gitignore'] ?? false);
         $compress = $input->getOption('compress') ?? $fileConfig['compress'] ?? false;
         $maxTokens = (int)($input->getOption('max-tokens') ?? $fileConfig['max-tokens'] ?? 0);
         $incrementalMode = $input->getOption('incremental') ?? $fileConfig['incremental'] ?? false;

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vangelis\RepoPHP\Config;
+
+class ConfigLoader
+{
+    private const CONFIG_FILENAMES = [
+        '.repophp.json',
+        'repophp.json',
+        '.repophp.config.json',
+        'repophp.config.json'
+    ];
+
+    /**
+     * Load configuration from file in current directory
+     */
+    public static function loadConfig(): array
+    {
+        $configPath = self::findConfigFile();
+        if (!$configPath) {
+            return [];
+        }
+
+        $configContent = file_get_contents($configPath);
+        if ($configContent === false) {
+            return [];
+        }
+
+        $config = json_decode($configContent, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException('Invalid JSON in config file: ' . json_last_error_msg());
+        }
+
+        return $config;
+    }
+
+    /**
+     * Find configuration file in current directory
+     */
+    private static function findConfigFile(): ?string
+    {
+        $currentDir = getcwd();
+
+        foreach (self::CONFIG_FILENAMES as $filename) {
+            $path = $currentDir . DIRECTORY_SEPARATOR . $filename;
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -10,7 +10,7 @@ class ConfigLoader
         '.repophp.json',
         'repophp.json',
         '.repophp.config.json',
-        'repophp.config.json'
+        'repophp.config.json',
     ];
 
     /**
@@ -19,7 +19,7 @@ class ConfigLoader
     public static function loadConfig(): array
     {
         $configPath = self::findConfigFile();
-        if (!$configPath) {
+        if (! $configPath) {
             return [];
         }
 

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Vangelis\RepoPHP\Tests\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+use Vangelis\RepoPHP\Config\ConfigLoader;
+
+class ConfigLoaderTest extends TestCase
+{
+    private string $tempDir;
+    private string $originalDir;
+
+    protected function setUp(): void
+    {
+        $this->originalDir = getcwd();
+        $this->tempDir = sys_get_temp_dir() . '/repophp_config_test_' . uniqid();
+        mkdir($this->tempDir);
+        chdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalDir);
+        if (file_exists($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
+    }
+
+    public function testLoadsConfigFromFile(): void
+    {
+        $config = [
+            'repository' => '/path/to/repo',
+            'format' => 'markdown',
+            'encoding' => 'cl100k_base'
+        ];
+
+        file_put_contents($this->tempDir . '/.repophp.json', json_encode($config));
+
+        $loadedConfig = ConfigLoader::loadConfig();
+        $this->assertEquals($config, $loadedConfig);
+    }
+
+    public function testReturnsEmptyArrayIfNoConfigFile(): void
+    {
+        $this->assertEquals([], ConfigLoader::loadConfig());
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = "$dir/$file";
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -31,7 +31,7 @@ class ConfigLoaderTest extends TestCase
         $config = [
             'repository' => '/path/to/repo',
             'format' => 'markdown',
-            'encoding' => 'cl100k_base'
+            'encoding' => 'cl100k_base',
         ];
 
         file_put_contents($this->tempDir . '/.repophp.json', json_encode($config));


### PR DESCRIPTION
This commit adds the ability to use configuration files to override default settings in RepoPHP. Users can now place a configuration file in their project directory and simply run vendor/bin/repophp without specifying all the command-line options.

The implementation includes:

- New ConfigLoader class to find and load configuration from JSON files
- Support for multiple config file names (.repophp.json, repophp.json, etc.)
- Modified PackCommand to merge config file settings with command line options
- Updated README with documentation about the configuration file format
- Added tests for the new configuration functionality

With this change, users can create a JSON configuration file in their project directory and the tool will automatically detect and use those settings, making it easier to consistently use the same options across multiple runs.